### PR TITLE
HTTPS support

### DIFF
--- a/src/BrightcoveVideoCloudEditor/VideoEditorUserControl.ascx
+++ b/src/BrightcoveVideoCloudEditor/VideoEditorUserControl.ascx
@@ -7,8 +7,8 @@
 <%@ Register Tagprefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPages" Assembly="Microsoft.SharePoint, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
 <%@ Control Language="C#" AutoEventWireup="true" CodeBehind="VideoEditorUserControl.ascx.cs" Inherits="BrightcoveVideoCloudIntegration.VideoEditor.VideoEditorUserControl" %>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
-<script language="JavaScript" type="text/javascript" src="http://admin.brightcove.com/js/BrightcoveExperiences.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
+<script language="JavaScript" type="text/javascript" src="https://sadmin.brightcove.com/js/BrightcoveExperiences.js"></script>
 <script type="text/javascript">
     $(document).ready(InitVideoEditor);
 

--- a/src/BrightcoveVideoCloudPicklist/VideoPicklistUserControl.ascx
+++ b/src/BrightcoveVideoCloudPicklist/VideoPicklistUserControl.ascx
@@ -9,7 +9,7 @@
 
 <div id="message" class="videoPicklist" runat="server"></div>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
 <script type="text/javascript">
     var queryStringKeyAsyncQueryText = "<%= BrightcoveVideoCloudIntegration.VideoCloudWebPart.QueryStringKeyAsyncQueryText %>";
     var queryStringKeyAsyncChooserText = "<%= BrightcoveVideoCloudIntegration.VideoCloudWebPart.QueryStringKeyAsyncChooserText %>";

--- a/src/BrightcoveVideoCloudPlayer/VideoPlayerUserControl.ascx
+++ b/src/BrightcoveVideoCloudPlayer/VideoPlayerUserControl.ascx
@@ -9,8 +9,8 @@
 
 <div id="message" class="videoPlayer" runat="server"></div>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
-<script language="JavaScript" type="text/javascript" src="http://admin.brightcove.com/js/BrightcoveExperiences.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
+<script language="JavaScript" type="text/javascript" src="https://sadmin.brightcove.com/js/BrightcoveExperiences.js"></script>
 <script language="JavaScript" type="text/javascript">
     var vcCurrentWeb = "<%= Microsoft.SharePoint.SPContext.Current.Web.Url %>";
 

--- a/src/BrightcoveVideoCloudPlaylist/VideoPlaylistUserControl.ascx
+++ b/src/BrightcoveVideoCloudPlaylist/VideoPlaylistUserControl.ascx
@@ -7,7 +7,7 @@
 <%@ Register Tagprefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPages" Assembly="Microsoft.SharePoint, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
 <%@ Control Language="C#" AutoEventWireup="true" CodeBehind="VideoPlaylistUserControl.ascx.cs" Inherits="BrightcoveVideoCloudIntegration.VideoPlaylist.VideoPlaylistUserControl" %>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
 <script type="text/javascript">
 var vcPlaylistId = "<%= this.PlaylistId %>";
 var vcPlayVideoLink = "<%= this.PlayVideoLink %>";
@@ -294,7 +294,7 @@ function CopyBlogCode(pid) {
             width + '&amp;height=' + height + '&amp;flashID=' + opid + '&amp;playerID=' + playerId + '&amp;%40playlistTabs=' +
             pid + '&amp;%40playlistCombo=' + pid + '&amp;%40videoList=' + pid + '&amp;dynamicStreaming=true&amp;cacheAMFURL=http%3A%2F%2Fshare.brightcove.com%2Fservices%2Fmessagebroker%2Famf&amp;secureConnections=true&amp;bgcolor=%23' + 
             bgColor + '&amp;autoStart=true&amp;isVid=true&amp;isUI=true&amp;debuggerID=">' + 
-		'    <param name="Base" value="http://admin.brightcove.com">' + 
+		'    <param name="Base" value="https://sadmin.brightcove.com">' + 
 		'    <param name="AllowScriptAccess" value="always">' + 
 		'    <param name="BGColor" value="' + bgColor + '">' + 
 		'    <param name="SWRemote" value="">' + 
@@ -302,7 +302,7 @@ function CopyBlogCode(pid) {
 		'    <param name="AllowNetworking" value="all">' + 
 		'    <param name="AllowFullScreen" value="true">' + 
 		'    <embed src="http://c.brightcove.com/services/viewer/federated_f9?isVid=1&isUI=1" bgcolor="#' + bgColor + '" flashVars="@40playlistTabs=' +
-            pid + '&@playlistCombo=' + pid + '&playerID=' + playerId + '&@videoList=' + pid + '&playerKey=AQ~~,AAAA5HYg_Wk~,dVrb4Dhl3iu-bD2b6KPfevAEl_qyND1e&domain=embed&dynamicStreaming=true" base="http://admin.brightcove.com" name="flashObj" width="' + 
+            pid + '&@playlistCombo=' + pid + '&playerID=' + playerId + '&@videoList=' + pid + '&playerKey=AQ~~,AAAA5HYg_Wk~,dVrb4Dhl3iu-bD2b6KPfevAEl_qyND1e&domain=embed&dynamicStreaming=true" base="https://sadmin.brightcove.com" name="flashObj" width="' + 
             width + '" height="' + height + '" seamlesstabbing="false" type="application/x-shockwave-flash" allowFullScreen="true" allowScriptAccess="always" swLiveConnect="true" pluginspage="http://www.macromedia.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash">' +
 		'    </embed>' + 
 	    '</object>';

--- a/src/BrightcoveVideoCloudSearch/VideoSearchUserControl.ascx
+++ b/src/BrightcoveVideoCloudSearch/VideoSearchUserControl.ascx
@@ -7,7 +7,7 @@
 <%@ Register Tagprefix="WebPartPages" Namespace="Microsoft.SharePoint.WebPartPages" Assembly="Microsoft.SharePoint, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c" %>
 <%@ Control Language="C#" AutoEventWireup="true" CodeBehind="VideoSearchUserControl.ascx.cs" Inherits="BrightcoveVideoCloudIntegration.VideoSearch.VideoSearchUserControl" %>
 
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.6.1/jquery.min.js" type="text/javascript"></script>
 <script type="text/javascript">
     $(document).ready(InitVideoSearch);
 
@@ -50,9 +50,9 @@
     function CopyBlogCode(vid) {
         var blog = '<object id="flashObj" width="640" height="390" classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,47,0"><param name="movie" value="http://c.brightcove.com/services/viewer/federated_f9?isVid=1&isUI=1" /><param name="bgcolor" value="#FFFFFF" /><param name="flashVars" value="@videoPlayer=' +
             vid + '&playerID=' + 
-            vcDefaultPlayerId + '&playerKey=AQ~~,AAAA5HYg_Wk~,dVrb4Dhl3iu-bD2b6KPfevAEl_qyND1e&domain=embed&dynamicStreaming=true" /><param name="base" value="http://admin.brightcove.com" /><param name="seamlesstabbing" value="false" /><param name="allowFullScreen" value="true" /><param name="swLiveConnect" value="true" /><param name="allowScriptAccess" value="always" /><embed src="http://c.brightcove.com/services/viewer/federated_f9?isVid=1&isUI=1" bgcolor="#FFFFFF" flashVars="@videoPlayer=' +
+            vcDefaultPlayerId + '&playerKey=AQ~~,AAAA5HYg_Wk~,dVrb4Dhl3iu-bD2b6KPfevAEl_qyND1e&domain=embed&dynamicStreaming=true" /><param name="base" value="https://sadmin.brightcove.com" /><param name="seamlesstabbing" value="false" /><param name="allowFullScreen" value="true" /><param name="swLiveConnect" value="true" /><param name="allowScriptAccess" value="always" /><embed src="http://c.brightcove.com/services/viewer/federated_f9?isVid=1&isUI=1" bgcolor="#FFFFFF" flashVars="@videoPlayer=' +
             vid + '&playerID=' + 
-            vcDefaultPlayerId + '&playerKey=AQ~~,AAAA5HYg_Wk~,dVrb4Dhl3iu-bD2b6KPfevAEl_qyND1e&domain=embed&dynamicStreaming=true" base="http://admin.brightcove.com" name="flashObj" width="640" height="390" seamlesstabbing="false" type="application/x-shockwave-flash" allowFullScreen="true" allowScriptAccess="always" swLiveConnect="true" pluginspage="http://www.macromedia.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"></embed></object>';
+            vcDefaultPlayerId + '&playerKey=AQ~~,AAAA5HYg_Wk~,dVrb4Dhl3iu-bD2b6KPfevAEl_qyND1e&domain=embed&dynamicStreaming=true" base="https://sadmin.brightcove.com" name="flashObj" width="640" height="390" seamlesstabbing="false" type="application/x-shockwave-flash" allowFullScreen="true" allowScriptAccess="always" swLiveConnect="true" pluginspage="http://www.macromedia.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash"></embed></object>';
         prompt('Copy this HTML code to add the video to your blog', blog);
         //window.clipboardData.setData('Text', blog);
     }


### PR DESCRIPTION
I made a couple changes to allow the web parts to work on a SharePoint instance that is served over SSL.  Originally jquery and the Brightcove API were loaded specifically over HTTP which caused browsers to warn the user about mixed or unsecure content.  

JQuery can be loaded with a protocol-relative link and the Brightcove API is always loaded via HTTPS since they have separate domains for HTTP and HTTPS.
